### PR TITLE
Use pkg-config for SDL path instead of hardcoding

### DIFF
--- a/cbits/rendering.h
+++ b/cbits/rendering.h
@@ -1,8 +1,8 @@
 #ifndef _RENDERING_H
 #define _RENDERING_H
 
-#include "SDL2/SDL.h"
-#include "SDL2/SDL_ttf.h"
+#include "SDL.h"
+#include "SDL_ttf.h"
 
 extern DECLSPEC SDL_Surface * SDLCALL TTF_RenderText_Solid1(TTF_Font *font,
                 const char *text, SDL_Color *fg);

--- a/sdl2-ttf.cabal
+++ b/sdl2-ttf.cabal
@@ -1,39 +1,45 @@
 Cabal-Version:      >= 1.10
 Name:               sdl2-ttf
 Version:            1.0.0
-Maintainer:         Rongcui Dong (karl_1702@188.com)
-Author:             Ömer Sinan Ağacan (omeragacan@gmail.com)
+maintainer:         Rongcui Dong (karl_1702@188.com)
+author:             Ömer Sinan Ağacan (omeragacan@gmail.com)
                   , Sean Chalmers (sclhiannan@gmail.com)
-License-File:       LICENSE
-License:            MIT
-Build-Type:         Simple
-Category:           Foreign binding
-Synopsis:           Binding to libSDL2-ttf
-Description:        Haskell bindings to the sdl2-ttf C++ library <http://www.libsdl.org/projects/SDL_ttf/>.
-Data-files:
+license-file:       LICENSE
+license:            MIT
+build-type:         Simple
+category:           Foreign binding
+synopsis:           Binding to libSDL2-ttf
+description:        Haskell bindings to the sdl2-ttf C++ library <http://www.libsdl.org/projects/SDL_ttf/>.
+data-files:
 extra-source-files: cbits/rendering.h
                     examples/ARIAL.TTF
                     examples/font_test.c
 
-Library
-  Hs-source-dirs:     src
-  Build-Depends:      base >= 3 && < 5, sdl2 >= 2, transformers
+library
+  hs-source-dirs:     src
+  build-depends:      base >= 3 && < 5, sdl2 >= 2, transformers
   default-extensions: ForeignFunctionInterface
-  Exposed-Modules:    SDL.TTF.Types,
+  exposed-modules:    SDL.TTF.Types,
                       SDL.TTF.FFI
                       SDL.TTF
   other-modules:      SDL.TTF.Internals
-  GHC-Options:        -Wall
+  ghc-options:        -Wall
   include-dirs:       cbits
-  C-sources:          cbits/rendering.c
+  c-sources:          cbits/rendering.c
+
+  includes: SDL.h
+
   extra-libraries:    SDL2, SDL2_ttf
+
+  pkgconfig-depends:  sdl2 >= 2.0.2
+
   default-language:   Haskell2010
 
 executable font-test
   main-is:          font_test.hs
   hs-source-dirs:   examples
   build-depends:    base >= 3 && <5, sdl2, sdl2-ttf, linear
-  GHC-Options:      -Wall
+  ghc-options:      -Wall
   default-language: Haskell2010
 
 source-repository head

--- a/sdl2-ttf.cabal
+++ b/sdl2-ttf.cabal
@@ -27,11 +27,7 @@ library
   include-dirs:       cbits
   c-sources:          cbits/rendering.c
 
-  includes: SDL.h
-
-  extra-libraries:    SDL2, SDL2_ttf
-
-  pkgconfig-depends:  sdl2 >= 2.0.2
+  pkgconfig-depends:  sdl2 >= 2.0.2, SDL2_ttf >= 2
 
   default-language:   Haskell2010
 

--- a/src/SDL/TTF.hsc
+++ b/src/SDL/TTF.hsc
@@ -46,8 +46,6 @@ import SDL.TTF.Internals
 import Control.Monad.IO.Class
 import Prelude hiding (init)
 
-import Debug.Trace
-
 -- | Initialize the truetype font API.
 -- This must be called before using other functions in this library, 
 -- except TTF_WasInit.

--- a/src/SDL/TTF/FFI.hsc
+++ b/src/SDL/TTF/FFI.hsc
@@ -1,4 +1,4 @@
-#include "SDL2/SDL_ttf.h"
+#include "SDL_ttf.h"
 module SDL.TTF.FFI where
 
 import Foreign.C

--- a/src/SDL/TTF/Types.hsc
+++ b/src/SDL/TTF/Types.hsc
@@ -1,4 +1,4 @@
-#include "SDL2/SDL_ttf.h"
+#include "SDL_ttf.h"
 {-# LANGUAGE EmptyDataDecls #-}
 module SDL.TTF.Types where
 


### PR DESCRIPTION
This lets it install without configuration changes (including on Windows), by using pkg-config for the include directories.
