### PR TITLE
use SDL_GetError instead of TTF_GetError

### DIFF
--- a/src/SDL/TTF/FFI.hsc
+++ b/src/SDL/TTF/FFI.hsc
@@ -18,7 +18,7 @@ foreign import ccall unsafe "TTF_WasInit"
 foreign import ccall unsafe "TTF_Quit"
   quit :: IO ()
 
-foreign import ccall unsafe "TTF_GetError"
+foreign import ccall unsafe "SDL_GetError"
   getTTFError :: IO CString
 
 foreign import ccall unsafe "TTF_OpenFont"


### PR DESCRIPTION
TTF_GetError has been a macro for SDL_GetError for some time now
http://hg.libsdl.org/SDL_ttf/file/3b93536d291a/SDL_ttf.h#l272