### PR TITLE
Add a cpp-options workaround for windows

### DIFF
--- a/sdl2-ttf.cabal
+++ b/sdl2-ttf.cabal
@@ -30,6 +30,9 @@ library
   pkgconfig-depends:  sdl2 >= 2.0.2, SDL2_ttf >= 2
 
   default-language:   Haskell2010
+  
+  if os(windows)
+    cpp-options: -D_SDL_main_h
 
 executable font-test
   main-is:          font_test.hs


### PR DESCRIPTION
This is an implementation of this hack: https://github.com/haskell-game/sdl2/issues/139
It compiles fine on Linux and fixes compilations on Widows (appveyor).